### PR TITLE
ci: add a2a documentation-agent for resolving current docs

### DIFF
--- a/.github/workflows/tasks.yml
+++ b/.github/workflows/tasks.yml
@@ -83,6 +83,8 @@ jobs:
               your work is complete (body refined, fix pushed, or comment posted).
           plugins: |
             ayghri/i-have-adhd
+          agents: |
+            documentation-agent
           anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           google-api-key: ${{ secrets.GOOGLE_API_KEY }}


### PR DESCRIPTION
## OpenTask Agent workflow

This PR adds the OpenTask Agent workflow to this repository. It uses [inference-gateway/infer-action](https://github.com/inference-gateway/infer-action) to run the OpenTask agent on issues and pull requests. The model is a workflow input (dropdown), defaulting to `ollama_cloud/deepseek-v4-flash`.

### Setup

Before the workflow can run:

1. Go to Settings > Secrets and variables > Actions and add the provider API key secret for the model(s) you use: `OLLAMA_CLOUD_API_KEY`, `DEEPSEEK_API_KEY`, `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_API_KEY`, `MOONSHOT_API_KEY`.
2. Add the `OPENTASK_APP_PRIVATE_KEY` secret with your GitHub App's private key. The workflow authenticates as your App via [actions/create-github-app-token](https://github.com/actions/create-github-app-token), so its comments and commits are attributed to the App.

The workflow triggers on new/edited issues, issue comments, and pull request review comments, and can also be run manually (Actions > Task > Run workflow) with a model chosen from the dropdown.

### Project board tracking

When an issue it works on is on a GitHub project board, the agent keeps the board's Status in sync (In Progress on start, Done on completion), best-effort. Board writes require a token with **Projects** permission: the default `GITHUB_TOKEN` cannot access Projects v2, so enable the GitHub App option (with Projects: read and write) for this to take effect - your App must grant it. Without it the agent skips board updates silently and does the rest of its work normally.

### Plugins

The workflow pre-installs the following infer-action plugins to extend the agent's capabilities:

- `ayghri/i-have-adhd`

### Agents

The workflow spins up the following A2A agents from the [agents registry](https://github.com/inference-gateway/agents) and exposes them to the OpenTask agent:

- `documentation-agent`
