### PR TITLE
fix(ci): use GitHub App client-id from secret for releaser token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/create-github-app-token@v3.2.0
         id: app-token
         with:
-          client-id: 4395087
+          client-id: ${{ secrets.RELEASER_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASER_APP_PRIVATE_KEY }}
 
       - uses: actions/checkout@v7.0.1


### PR DESCRIPTION
## Summary

The releaser was passing the App ID (`4395087`) into the `client-id` input of `create-github-app-token`, so the minted token wasn't attributed to the bypass integration and `semantic-release`'s push to `main` was rejected by the `push-main` ruleset (`GH013`).

## Changes

- Pass the app's real Client ID via new `RELEASER_APP_CLIENT_ID` secret instead of the App ID.