### PR TITLE
ci: sync OpenTask Agent workflow

### DIFF
--- a/.github/workflows/tasks.yml
+++ b/.github/workflows/tasks.yml
@@ -4,18 +4,19 @@ on:
   workflow_dispatch:
     inputs:
       model:
-        description: Model to use
-        type: choice
+        description: Model to use (provider/model, e.g. llamacpp/phi-4)
+        required: false
         default: ollama_cloud/deepseek-v4-flash
-        options:
-          - ollama_cloud/deepseek-v4-flash
-          - deepseek/deepseek-v4-flash
-          - anthropic/claude-sonnet-4-6
-          - openai/gpt-5
-          - google/gemini-3-pro
-          - moonshot/kimi-k2
       prompt:
         description: Task for the agent (workflow_dispatch only)
+        required: false
+        default: ""
+      enable_git:
+        description: Enable git operations - branch, commit, PR (workflow_dispatch only)
+        required: false
+        default: "true"
+      system_prompt:
+        description: Override the direct-prompt system prompt (workflow_dispatch only)
         required: false
         default: ""
   issues:
@@ -42,21 +43,29 @@ jobs:
       - uses: actions/create-github-app-token@v3.2.0
         id: app-token
         with:
-          client-id: 4394298
+          client-id: Iv23likOeTBSPtN9mbTj
           private-key: ${{ secrets.OPENTASK_APP_PRIVATE_KEY }}
 
       - uses: actions/checkout@v7.0.1
         with:
           token: ${{ steps.app-token.outputs.token }}
 
-      - uses: inference-gateway/infer-action@v0.35.2
+      - uses: arduino/setup-task@v3.0.0
+        with:
+          version: 3.x
+
+      - uses: inference-gateway/infer-action@v0.36.0
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           github-app-slug: ${{ steps.app-token.outputs.app-slug }}
           trigger-phrase: "@opentask"
-          model: ${{ inputs.model || 'ollama_cloud/deepseek-v4-flash' }}
+          model: ${{ inputs.model || vars.DEFAULT_MODEL || 'ollama_cloud/deepseek-v4-flash' }}
+          llamacpp-api-url: ${{ secrets.LLAMACPP_API_URL }}
+          llamacpp-api-key: ${{ secrets.LLAMACPP_API_KEY }}
           direct-prompt: ${{ inputs.prompt }}
-          enable-git-operations: "true"
+          system-prompt-direct: ${{ inputs.system_prompt }}
+          enable-git-operations: "${{ inputs.enable_git || 'true' }}"
+          debug: "false"
           bash-allow-append: "gh project list( .*)?,gh project field-list( .*)?,gh project item-add( .*)?,gh project item-edit( .*)?,gh issue create( .*)?,gh issue edit( .*)?,gh issue comment( .*)?,gh pr comment( .*)?"
           custom-instructions: |
             When working on a GitHub issue that belongs to a project board, keep the board's status in


### PR DESCRIPTION
## OpenTask Agent workflow

This PR adds the OpenTask Agent workflow to this repository. It uses [inference-gateway/infer-action](https://github.com/inference-gateway/infer-action) to run the OpenTask agent on issues and pull requests. The model is a workflow input (dropdown), defaulting to `ollama_cloud/deepseek-v4-flash`.

### Setup

Before the workflow can run:

1. Go to Settings > Secrets and variables > Actions and add the provider API key secret for the model(s) you use: `OLLAMA_CLOUD_API_KEY`, `DEEPSEEK_API_KEY`, `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_API_KEY`, `MOONSHOT_API_KEY`.
2. Add the `OPENTASK_APP_PRIVATE_KEY` secret with your GitHub App's private key. The workflow authenticates as your App via [actions/create-github-app-token](https://github.com/actions/create-github-app-token), so its comments and commits are attributed to the App.

The workflow triggers on new/edited issues, issue comments, and pull request review comments, and can also be run manually (Actions > Task > Run workflow) with a model chosen from the dropdown.

### Self-hosted llama.cpp (RunPod GPU)

To route runs to a self-hosted llama.cpp endpoint (e.g. a GPU provisioned from the OpenTask popup), add to Settings > Secrets and variables > Actions:

- Secret `LLAMACPP_API_URL` - the endpoint base URL shown in the popup, e.g. `https://<pod>-8080.proxy.runpod.net/v1`.
- Secret `LLAMACPP_API_KEY` - the bearer token shown in the popup (the pod is started with `--api-key`).
- (Optional) Variable `DEFAULT_MODEL` - overrides the default model for issue/comment-triggered runs, e.g. `llamacpp/<model>`. Manual/dispatch runs still use the picker.

### Project board tracking

When an issue it works on is on a GitHub project board, the agent keeps the board's Status in sync (In Progress on start, Done on completion), best-effort. Board writes require a token with **Projects** permission: the default `GITHUB_TOKEN` cannot access Projects v2, so enable the GitHub App option (with Projects: read and write) for this to take effect - your App must grant it. Without it the agent skips board updates silently and does the rest of its work normally.

### Plugins

The workflow pre-installs the following infer-action plugins to extend the agent's capabilities:

- `DietrichGebert/ponytail`
- `ayghri/i-have-adhd`

### Agents

The workflow spins up the following A2A agents from the [agents registry](https://github.com/inference-gateway/agents) and exposes them to the OpenTask agent:

- `documentation-agent`
