### PR TITLE
chore: update OpenTask skills

### DIFF
--- a/.agents/skills/cpp-best-practices/SKILL.md
+++ b/.agents/skills/cpp-best-practices/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: cpp-best-practices
+description: >
+  Write modern C++ the way the C++ Best Practices community (Jason Turner / `lefticus`) teaches it - const-correct,
+  RAII-only ownership, algorithms over raw loops, strong types over stringly-typed interfaces, and a build that turns
+  the compiler and sanitizers into the first line of defence. Use when writing, refactoring, or scaffolding C++ code,
+  picking between `unique_ptr`/`shared_ptr`/value semantics, choosing warning and sanitizer flags, or deciding which
+  language feature to reach for.
+license: Apache-2.0
+---
+
+# C++ Best Practices
+
+Use this skill when authoring or refactoring C++, or when setting up the build so mistakes fail loudly instead of
+silently.
+
+## The order of operations
+
+1. **Make the tools catch it.** Any rule below that a compiler flag, a clang-tidy check, or a sanitizer can enforce
+   should be enforced there, not in review. Configure that first.
+2. **Make it correct.** Types that cannot represent the wrong thing beat runtime checks.
+3. **Make it clear.** Standard algorithms and value semantics over hand-rolled loops and pointers.
+4. **Then, only if measured, make it fast.**
+
+## Turn the compiler into a static analyzer
+
+Baseline that should be on for every target - the `cpp-best-practices/cmake_template` defaults, plus `-Wsign-conversion`
+from the book's tooling chapter.
+
+```text
+GCC/Clang: -Wall -Wextra -Wshadow -Wnon-virtual-dtor -Wold-style-cast -Wcast-align -Wunused
+           -Woverloaded-virtual -Wpedantic -Wconversion -Wsign-conversion -Wnull-dereference
+           -Wdouble-promotion -Wformat=2 -Wimplicit-fallthrough
+GCC also:  -Wmisleading-indentation -Wduplicated-cond -Wduplicated-branches -Wlogical-op
+           -Wuseless-cast -Wsuggest-override
+MSVC:      /W4 /permissive- (plus the off-by-default /w14xxx set: 4242 4254 4263 4265 4287 4289
+           4296 4311 4545 4546 4547 4549 4555 4619 4640 4826 4905 4906 4928)
+```
+
+Rules of thumb:
+
+- `-Werror` in CI, not necessarily in a developer's local build.
+- Suppress a warning at the narrowest possible scope, with a comment saying why. A project-wide `-Wno-` is a decision
+  to stop being told about a whole class of bug.
+- Dependencies are not your code: include them as `SYSTEM` so their headers do not drown your warnings.
+
+Then add, in rough order of value per unit of effort: **clang-tidy** (`Checks: "*"` minus the vendor-specific
+`abseil-*`, `altera-*`, `android-*`, `fuchsia-*`, `google-*`, `llvm*`, `zircon-*` groups plus
+`modernize-use-trailing-return-type`), **ASan+UBSan** and **TSan** builds in CI, **cppcheck `--enable=all`**, and a
+**libFuzzer** target for anything that parses untrusted input. Hardening (`_FORTIFY_SOURCE=3`,
+`-D_GLIBCXX_ASSERTIONS`, `-fstack-protector-strong`, control-flow guard) belongs in release builds, not just debug.
+
+## Ownership and memory
+
+- No naked `new`/`delete`, no owning raw pointers. `std::unique_ptr` by default; `std::shared_ptr` only when ownership
+  is genuinely shared and you can name the second owner.
+- Build them with `std::make_unique` / `std::make_shared` - one allocation instead of two, and exception-safe.
+- Return `unique_ptr` from factories. A caller who needs sharing can convert; the reverse is not possible.
+- `std::array` or `std::vector` instead of C arrays; `std::span` to pass a non-owning view of either. Never
+  `shared_ptr<T[]>`.
+- A raw pointer or reference in a signature means "I observe this, I do not own it", and must not outlive the callee.
+
+## Const and the shape of interfaces
+
+- `const` on everything that is not mutated: locals, member functions, references. It documents intent and unlocks
+  optimizations.
+- Pass cheap types (`int`, `double`, enums, `string_view`, `span`) **by value**. Pass expensive types by `const&`. A
+  `const int&` parameter is a pessimization.
+- Prefer returning by value; it is move-friendly and thread-safe. Return `const&` from a getter only when the normal
+  use is observation and the lifetime is obvious.
+- Mark single-argument constructors `explicit` unless implicit conversion is a designed feature.
+- Avoid `bool` parameters - `draw(shape, true)` tells the reader nothing. Use a scoped enum or split the function.
+- Avoid stringly-typed interfaces. `std::filesystem::path` beats `std::string` for a path; a strong typedef beats
+  `int` for an ID. Types that cannot be mixed up will not be mixed up.
+
+## Language usage
+
+- `static_cast` / `dynamic_cast` / `const_cast` / `reinterpret_cast`, never a C-style cast. They are checked and they
+  are greppable.
+- `constexpr` (and `consteval`, `constinit`) instead of macros for constants; templates and `if constexpr` instead of
+  macros for logic. The preprocessor is invisible to the debugger.
+- Declare variables as late as possible and initialize them at declaration. Use `if (auto x = f(); cond)` init
+  statements to keep scope tight.
+- Use `override` on every override and `final` where a hierarchy is closed. Do not repeat `virtual` on an override.
+- Follow the rule of zero: let a class own resources through members that already manage themselves, and declare none
+  of the five special members. If you must declare one, declare all that apply - declaring a destructor suppresses the
+  implicit move operations and silently turns moves into copies.
+- Never put a side effect inside `assert` - it evaporates in release builds. Assign to a `[[maybe_unused]]` local and
+  assert on that.
+- Prefer `++i` to `i++` when the result is unused, `'\n'` to `"\n"`, and `"\n"` to `std::endl` (which forces a flush).
+- Use a lambda, not `std::bind`.
+- Prefer exceptions to error codes when failure is exceptional; prefer `std::optional` / `std::expected` when it is
+  not. Either way, do not return a code that a caller can silently ignore.
+
+## Replace raw loops with algorithms
+
+Treat a hand-written loop over a container - and especially an `operator[]` inside one - as a smell. Reach for
+`<algorithm>` and `<numeric>`, and for the C++20 ranges versions where available: `std::ranges::sort`,
+`find_if`, `any_of`/`all_of`/`none_of`, `transform`, `accumulate`/`reduce`, `views::filter`, `views::transform`.
+Named algorithms state the intent, come with the right complexity, and are already correct at the boundaries.
+
+## Performance, in the right order
+
+Never optimize without a profile. Once you have one:
+
+- Fix the algorithm and the data layout first; micro-optimizations cannot rescue an O(n²) scan or a pointer-chasing
+  layout.
+- Kill temporaries and copies. `reserve()` before a loop that pushes. Prefer initializer lists to repeated
+  `push_back`. `emplace_back` to construct in place.
+- `shared_ptr` copies are atomic refcount traffic - pass `const shared_ptr&`, or better, pass the underlying reference.
+- Heap allocation is the usual hidden cost. Prefer stack and value semantics; consider `std::pmr` arenas for
+  allocation-heavy hot paths.
+- Build times are performance too: forward declare instead of including, keep templates thin, and run
+  `include-what-you-use`.
+
+## Sources
+
+The practices above summarize the community consensus documented in Jason Turner's
+[C++ Best Practices](https://github.com/cpp-best-practices/cppbestpractices) book (CC BY-NC 4.0 - referenced, not
+reproduced), the [`cmake_template`](https://github.com/cpp-best-practices/cmake_template) project defaults, and the
+[C++ Core Guidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines). See also
+[C++ Weekly](https://github.com/lefticus/cpp_weekly). For review workflow use `cpp-review`; for threading use
+`cpp-concurrency`.

--- a/.agents/skills/cpp-concurrency/SKILL.md
+++ b/.agents/skills/cpp-concurrency/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: cpp-concurrency
+description: >
+  Write and review concurrent C++ the way the C++ Best Practices community (Jason Turner / `lefticus`) frames it -
+  design shared state away first, then use `std::jthread`, scoped locks, the mutex-and-mutable rule, and
+  ThreadSanitizer to make what is left provably safe. Use when adding threads, thread pools, async work, or atomics,
+  when diagnosing a data race, deadlock, or heisenbug, when choosing between `jthread`/`async`/executors, or when
+  reviewing code that shares mutable state.
+license: Apache-2.0
+---
+
+# C++ Concurrency
+
+Use this skill when adding, reviewing, or debugging threaded C++.
+
+## Design the sharing away first
+
+Most concurrency bugs are the consequence of an ownership decision made long before the first `std::thread`.
+
+- **Avoid global data.** Globals, function-local statics, and singletons are shared state whether or not you meant
+  them to be, and they are what makes a component impossible to parallelize later. `std::shared_ptr` is in the same
+  family - it is a licence for two pieces of code to touch the same object.
+- **Prefer message passing to shared memory.** A queue with values moved through it needs one lock, in one place, that
+  you can reason about. A graph of objects protected by "whichever mutex the author remembered" cannot be reasoned
+  about at all.
+- **Prefer immutability.** Data that is never written after publication needs no synchronization at all.
+- **Return by value from anything reachable by two threads.** Returning `const&` hands out a reference whose referent
+  another thread may be mutating; the caller has no way to know.
+- **Watch the heap.** Allocation is a shared resource with a global lock underneath it. Allocation-heavy code often
+  scales worse than the same code copying values; measure before assuming threads made it faster.
+
+## The rules for what sharing remains
+
+- **Mutex and `mutable` go together (the M&M rule).** A `mutable` member is by presumption shared, so it must be
+  guarded by a mutex or be atomic. A member that _is_ a mutex must be `mutable`, so `const` member functions can lock
+  it. A `const` member function is a promise of thread-safety to callers, not merely of non-mutation.
+- **Never lock by hand.** `std::scoped_lock` (or `lock_guard`/`unique_lock`) always - it is exception-safe, and
+  `scoped_lock` takes multiple mutexes deadlock-free via a lock ordering. A bare `.lock()`/`.unlock()` pair is a leak
+  waiting for the next `throw` or early `return`.
+- **Establish a global lock order** and document it, for any code that ever holds two mutexes.
+- **Never call unknown code while holding a lock** - not a callback, not a virtual function, not an allocation you did
+  not budget for. That is how lock-order inversions and unbounded hold times get introduced by someone else's commit.
+- **Keep critical sections short and free of I/O.**
+- **`std::condition_variable` is always used with a predicate**: `cv.wait(lock, []{ return ready; })`. The
+  predicate-free overload is a spurious-wakeup bug. Set the state under the mutex before notifying.
+- **Prefer `std::jthread` (C++20).** It joins in its destructor and carries a `std::stop_token`, which removes the two
+  most common `std::thread` bugs: forgetting to join and having no way to cancel. Pass the token through and check
+  `stop_requested()` in the loop.
+- **`std::atomic` is for single variables, not for invariants across two of them.** Default to
+  `memory_order_seq_cst`; use a relaxed ordering only with a written justification and a TSan run. Hand-rolled
+  lock-free structures are almost never worth it - reach for a reviewed library first.
+- **`std::async` is a trap in disguise:** the returned future's destructor blocks for `std::launch::async`, and the
+  policy is implementation-chosen if you do not pass one. If you want a thread, say `jthread`; if you want a pool, use
+  a pool.
+- **Static local initialization is thread-safe (C++11 magic statics); ordinary static _destruction_ order is not**,
+  particularly across shared libraries. Do not rely on it.
+- **`const` on a standard-library object means safe for concurrent reads only.** Two threads reading the same
+  `std::vector` is fine; one writing while another reads is a race even if the reader holds a `const&`.
+- Remember `std::vector<bool>` and bitfields: adjacent elements share a word, so "different elements" is not
+  automatically "different memory locations".
+
+## Verification is not optional
+
+A data race is undefined behaviour, so testing without instrumentation proves nothing - the race that never fires on
+your laptop fires under a different scheduler.
+
+1. **ThreadSanitizer.** Build a dedicated TSan configuration (`-fsanitize=thread`, `-O1 -g`, no ASan in the same
+   binary) and run the full suite under it in CI. Treat any TSan report as a build failure.
+2. **Stress the schedule.** Run concurrency tests many times, on a machine under load, with more threads than cores.
+3. **Enable the hardened/checked standard library** (`-D_GLIBCXX_ASSERTIONS`, `_LIBCPP_HARDENING_MODE`) in test
+   builds.
+4. **Deadlocks:** reproduce, then attach a debugger and dump all thread stacks (`thread apply all bt`). The cycle is
+   visible in the stacks; guessing at it is not.
+5. **Measure the speedup.** If the threaded version is not measurably faster than the serial one on realistic data,
+   delete the threads - you have bought risk for nothing. Consider parallel algorithm execution policies
+   (`std::execution::par`) before hand-rolling anything.
+
+## Reviewing threaded code
+
+Ask, for each piece of mutable state the change touches: which mutex guards it, is that documented next to the
+member, and does every access path take it? A member whose answer is "it's only touched from one thread" needs that
+assertion written down - ideally as an assert - because the next author will not infer it.
+
+## Sources
+
+Builds on the "Considering Threadability" guidance in Jason Turner's
+[C++ Best Practices](https://github.com/cpp-best-practices/cppbestpractices) (CC BY-NC 4.0 - referenced, not
+reproduced), Herb Sutter's writing on `const` and the M&M rule, and the concurrency section of the
+[C++ Core Guidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#S-concurrency). See also
+[C++ Weekly](https://github.com/lefticus/cpp_weekly). Related skills: `cpp-best-practices`, `cpp-review`.

--- a/.agents/skills/cpp-review/SKILL.md
+++ b/.agents/skills/cpp-review/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: cpp-review
+description: >
+  Review C++ code - a diff, a pull request, or a file - against the C++ Best Practices checklist popularized by Jason
+  Turner (`lefticus`): undefined behaviour and lifetime bugs first, then ownership, const-correctness, interface
+  design, and only then style. Use when asked to review, critique, or audit C++ code, when triaging a C++ pull
+  request, or when a C++ build is warning-clean but you still do not trust it. Prescribes running the tools
+  (warnings, clang-tidy, sanitizers) before reading, so the review spends its attention on what tools cannot see.
+license: Apache-2.0
+---
+
+# C++ Review
+
+Use this skill when reviewing C++ - a working diff, a PR, or a file someone asked you to look at.
+
+## Rule zero: run the tools before you read
+
+Anything a machine can find is not worth a human comment. Before reviewing, try in order (skip what the project has
+not configured, and say so in the review):
+
+1. Build with the project's warnings at maximum; read every new warning the change introduces.
+2. `clang-tidy` on the changed files only (`clang-tidy --line-filter=...`, or `run-clang-tidy` scoped to the diff).
+3. `cppcheck --enable=all` on the changed translation units.
+4. Run the tests under **ASan+UBSan**, and under **TSan** if any threading is touched. A green test suite without
+   sanitizers proves very little in C++.
+
+Report what you ran and what you could not run. A review that says "tests pass" when sanitizers were never enabled is
+overstating its evidence.
+
+## Then read, in this priority order
+
+Comment on the first category that fires. Do not bury a lifetime bug under nits about naming.
+
+### 1. Undefined behaviour and lifetime
+
+- Dangling references: a `const&` or `string_view`/`span` parameter stored in a member, captured by a lambda that
+  outlives the call, or bound to a temporary. `auto&& x = f().g();` is a classic.
+- Iterator/reference invalidation: a container mutated while iterated, or a reference held across a `push_back`.
+- Out-of-bounds indexing, `.front()`/`.back()`/`operator[]` on a possibly-empty container, `*` on an empty
+  `optional`.
+- Signed overflow, shifts by >= width, unaligned or type-punning `reinterpret_cast` (use `std::bit_cast` or
+  `memcpy`).
+- Uninitialized members - especially a constructor that assigns in the body instead of the member-init list, or a new
+  member added to an existing constructor and forgotten.
+- Order-of-initialization dependence between static objects in different translation units.
+- Anything returning a pointer or reference to a local.
+
+### 2. Ownership and resources
+
+- Naked `new`/`delete`, owning raw pointers, or manual `close`/`free` where RAII would do.
+- `shared_ptr` used where `unique_ptr` or a plain value would do; `shared_ptr` cycles; `shared_ptr` copied by value
+  into a function that only observes.
+- Rule of zero/five violations: a user-declared destructor (or copy ctor, or assignment) that silently disables move
+  operations and turns every "move" in the codebase into a copy.
+- Resources acquired on one path and released on another - if an exception can be thrown between them, it leaks.
+- Exception safety: does the function leave the object in a valid state if a mid-way operation throws? Is the strong
+  guarantee claimed but not delivered?
+
+### 3. Correctness of the interface
+
+- Signatures that admit wrong calls: two adjacent `int` parameters, `bool` flags, `std::string` where a
+  `std::filesystem::path` or a strong type belongs.
+- Missing `explicit` on a single-argument constructor; implicit conversions that the caller did not ask for.
+- Missing `const` on member functions; `mutable` members without a matching mutex (see `cpp-concurrency`).
+- `[[nodiscard]]` missing on a function whose return value must not be dropped.
+- Error reporting a caller can ignore: a returned status code with no `[[nodiscard]]`, or a swallowed exception.
+- `override` missing on an override; a base class with virtual functions and a public non-virtual destructor.
+
+### 4. Clarity and cost
+
+- Raw loops that a named algorithm (`std::ranges::find_if`, `any_of`, `transform`, `accumulate`) would state better.
+- Copies that could be moves or references: unnecessary temporaries, `push_back` in a loop without `reserve`,
+  by-value capture of a large object in a lambda.
+- Macros doing what `constexpr`, templates, or `if constexpr` would do.
+- C-style casts.
+- Variables declared far from first use, or declared uninitialized then assigned.
+- Dead flexibility: an interface with one implementation, a template parameter with one instantiation, a
+  configuration knob nothing sets.
+
+### 5. Tests
+
+- Does the change have a test that fails without it? For a bug fix, does the test reproduce the original bug?
+- Boundaries: empty container, single element, maximum size, self-assignment, self-move.
+- If the code parses untrusted input, is there a fuzz target?
+
+## Writing the review
+
+- One finding per comment, anchored at `file:line`, stating the concrete failure - the input or interleaving that
+  produces the wrong result - not a rule number.
+- Separate "this is a bug" from "I would write this differently". Do not let the second crowd out the first.
+- If a suggestion is a matter of taste and the codebase is internally consistent, drop it. Consistency with the
+  surrounding code beats consistency with any style guide.
+- If you could not verify a suspicion (no repro, no sanitizer run), say it is a suspicion.
+
+## Sources
+
+Checklist derived from Jason Turner's [C++ Best Practices](https://github.com/cpp-best-practices/cppbestpractices)
+(CC BY-NC 4.0 - referenced, not reproduced), the tooling defaults in
+[`cmake_template`](https://github.com/cpp-best-practices/cmake_template), and the
+[C++ Core Guidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines). For the practices being reviewed
+against, see `cpp-best-practices`; for threading review, see `cpp-concurrency`.


### PR DESCRIPTION
## Update OpenTask skills

Applied from the [Inference Gateway skills registry](https://github.com/inference-gateway/skills) via the browser extension. Skills live under `.agents/skills/`.

**Installed:** `cpp-concurrency`, `cpp-review`, `cpp-best-practices`
